### PR TITLE
Updating the StatusCake Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-statuscake
 
 require (
-	github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb
+	github.com/DreamItGetIT/statuscake v0.0.0-20190726070003-fcee7d205925
 	github.com/hashicorp/terraform v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNf
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb h1:vJ3lnCyZNmSV/OKyw4d7GuZHFrUaa3FY6/NqtvRE0lw=
 github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb/go.mod h1:OclNh7ZacJo61GDJablmsOZ7l8/AVtzGqP8G7baOdAs=
+github.com/DreamItGetIT/statuscake v0.0.0-20190726070003-fcee7d205925 h1:e7K6Ou4LM1CttT1rbYt5rgZYyCfTpUcXNNWyuuJ/1t4=
+github.com/DreamItGetIT/statuscake v0.0.0-20190726070003-fcee7d205925/go.mod h1:OclNh7ZacJo61GDJablmsOZ7l8/AVtzGqP8G7baOdAs=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=

--- a/vendor/github.com/DreamItGetIT/statuscake/Gopkg.lock
+++ b/vendor/github.com/DreamItGetIT/statuscake/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "UT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -30,7 +38,7 @@
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
   pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
@@ -41,8 +49,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DreamItGetIT/statuscake",
+    "github.com/google/go-querystring/query",
     "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/require",
+    "github.com/stretchr/testify/require"
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/DreamItGetIT/statuscake/ssl.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/ssl.go
@@ -1,0 +1,273 @@
+package statuscake
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"strconv"
+	
+	"github.com/google/go-querystring/query"
+)
+
+//Ssl represent the data received by the API with GET
+type Ssl struct {
+	ID             string              `json:"id"                 url:"id,omitempty"`
+	Domain         string              `json:"domain"             url:"domain,omitempty"`
+	Checkrate      int                 `json:"checkrate"          url:"checkrate,omitempty"`
+	ContactGroupsC string              `                          url:"contact_groups,omitempty"`
+	AlertAt        string              `json:"alert_at"           url:"alert_at,omitempty"`
+	AlertReminder  bool                `json:"alert_reminder"     url:"alert_expiry,omitempty"`
+	AlertExpiry    bool                `json:"alert_expiry"       url:"alert_reminder,omitempty"`
+	AlertBroken    bool                `json:"alert_broken"       url:"alert_broken,omitempty"`
+	AlertMixed     bool                `json:"alert_mixed"        url:"alert_mixed,omitempty"`
+	Paused         bool                `json:"paused"`
+	IssuerCn       string              `json:"issuer_cn"`
+	CertScore      string              `json:"cert_score"`
+	CipherScore    string              `json:"cipher_score"`
+	CertStatus     string              `json:"cert_status"`
+	Cipher         string              `json:"cipher"`
+	ValidFromUtc   string              `json:"valid_from_utc"`
+	ValidUntilUtc  string              `json:"valid_until_utc"`
+	MixedContent   []map[string]string `json:"mixed_content"`
+	Flags          map[string]bool     `json:"flags"`
+	ContactGroups  []string            `json:"contact_groups"`
+	LastReminder   int                 `json:"last_reminder"`
+	LastUpdatedUtc string              `json:"last_updated_utc"`
+}
+
+//PartialSsl represent  a ssl test creation or modification
+type PartialSsl struct {
+	ID             int
+	Domain         string
+	Checkrate      string
+	ContactGroupsC string
+	AlertAt        string
+	AlertExpiry    bool
+	AlertReminder  bool
+	AlertBroken    bool
+	AlertMixed     bool
+}
+
+type createSsl struct {
+	ID             int    `url:"id,omitempty"`
+	Domain         string `url:"domain"         json:"domain"`
+	Checkrate      string `url:"checkrate"      json:"checkrate"`
+	ContactGroupsC string `url:"contact_groups" json:"contact_groups"`
+	AlertAt        string `url:"alert_at"       json:"alert_at"`
+	AlertExpiry    bool   `url:"alert_expiry"   json:"alert_expiry"`
+	AlertReminder  bool   `url:"alert_reminder" json:"alert_reminder"`
+	AlertBroken    bool   `url:"alert_broken"   json:"alert_broken"`
+	AlertMixed     bool   `url:"alert_mixed"    json:"alert_mixed"`
+}
+
+type updateSsl struct {
+	ID             int    `url:"id"`
+	Domain         string `url:"domain"         json:"domain"`
+	Checkrate      string `url:"checkrate"      json:"checkrate"`
+	ContactGroupsC string `url:"contact_groups" json:"contact_groups"`
+	AlertAt        string `url:"alert_at"       json:"alert_at"`
+	AlertExpiry    bool   `url:"alert_expiry"   json:"alert_expiry"`
+	AlertReminder  bool   `url:"alert_reminder" json:"alert_reminder"`
+	AlertBroken    bool   `url:"alert_broken"   json:"alert_broken"`
+	AlertMixed     bool   `url:"alert_mixed"    json:"alert_mixed"`
+}
+
+
+type sslUpdateResponse struct {
+	Success bool   `json:"Success"`
+	Message interface{} `json:"Message"`
+}
+
+type sslCreateResponse struct {
+	Success bool   `json:"Success"`
+	Message interface{} `json:"Message"`
+	Input createSsl `json:"Input"`
+}
+
+//Ssls represent the actions done wit the API
+type Ssls interface {
+	All() ([]*Ssl, error)
+	completeSsl(*PartialSsl) (*Ssl, error)
+	Detail(string) (*Ssl, error)
+	Update(*PartialSsl) (*Ssl, error)
+	UpdatePartial(*PartialSsl) (*PartialSsl, error)
+	Delete(ID string) error
+	CreatePartial(*PartialSsl) (*PartialSsl, error)
+	Create(*PartialSsl) (*Ssl, error)
+}
+
+func consolidateSsl(s *Ssl) {
+	(*s).ContactGroupsC = strings.Trim(strings.Join(strings.Fields(fmt.Sprint((*s).ContactGroups)), ","), "[]")
+}
+
+func findSsl(responses []*Ssl, id string) (*Ssl, error) {
+	var response *Ssl
+	for _, elem := range responses {
+		if (*elem).ID == id {
+			return elem, nil
+		}
+	}
+	return response, fmt.Errorf("%s Not found", id)
+}
+
+func (tt *ssls) completeSsl(s *PartialSsl) (*Ssl, error) {
+	full, err := tt.Detail(strconv.Itoa((*s).ID))
+	if err != nil {
+		return nil, err
+	}
+	(*full).ContactGroups = strings.Split((*s).ContactGroupsC,",")
+	return full, nil
+}
+
+//Partial return a PartialSsl corresponding to the Ssl
+func Partial(s *Ssl) (*PartialSsl,error) {
+	if s==nil {
+		return nil,fmt.Errorf("s is nil")
+	}
+	id,err:=strconv.Atoi(s.ID)
+	if(err!=nil){
+		return nil,err
+	}
+	return &PartialSsl{
+		ID: id,
+		Domain: s.Domain,
+		Checkrate: strconv.Itoa(s.Checkrate),
+		ContactGroupsC: s.ContactGroupsC,
+		AlertReminder: s.AlertReminder,
+		AlertExpiry: s.AlertExpiry,
+		AlertBroken: s.AlertBroken,
+		AlertMixed: s.AlertMixed,
+		AlertAt: s.AlertAt,
+	},nil
+	
+}
+
+type ssls struct {
+	client apiClient
+}
+
+//NewSsls return a new ssls
+func NewSsls(c apiClient) Ssls {
+	return &ssls{
+		client: c,
+	}
+}
+
+//All return a list of all the ssl from the API
+func (tt *ssls) All() ([]*Ssl, error) {
+	rawResponse, err := tt.client.get("/SSL", nil)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting StatusCake Ssl: %s", err.Error())
+	}
+	var getResponse []*Ssl
+	err = json.NewDecoder(rawResponse.Body).Decode(&getResponse)
+	if err != nil {
+		return nil, err
+	}
+	
+	for ssl := range getResponse {
+		consolidateSsl(getResponse[ssl])
+	}
+	
+	return getResponse, err
+}
+
+//Detail return the ssl corresponding to the id 
+func (tt *ssls) Detail(id string) (*Ssl, error) {
+	responses, err := tt.All()
+	if err != nil {
+		return nil, err
+	}
+	mySsl, errF := findSsl(responses, id)
+	if errF != nil {
+		return nil, errF
+	}
+	return mySsl, nil
+}
+
+//Update update the API with s and create one if s.ID=0 then return the corresponding Ssl
+func (tt *ssls) Update(s *PartialSsl) (*Ssl, error) {
+	var err error
+	s, err = tt.UpdatePartial(s)
+	if err!= nil {
+		return nil, err
+	}
+	return tt.completeSsl(s)
+}
+
+//UpdatePartial update the API with s and create one if s.ID=0 then return the corresponding PartialSsl
+func (tt *ssls) UpdatePartial(s *PartialSsl) (*PartialSsl, error) {
+
+	if((*s).ID == 0){
+		return tt.CreatePartial(s)
+	}
+	var v url.Values
+
+	v, _ = query.Values(updateSsl(*s))
+	
+	rawResponse, err := tt.client.put("/SSL/Update", v)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating StatusCake Ssl: %s", err.Error())
+	}
+	
+	var updateResponse sslUpdateResponse
+	err = json.NewDecoder(rawResponse.Body).Decode(&updateResponse)
+	if err != nil {
+		return nil, err
+	}
+	
+	if !updateResponse.Success {
+		return nil, fmt.Errorf("%s", updateResponse.Message.(string))
+	}
+
+
+	return s, nil
+}
+
+//Delete delete the ssl which ID is id
+func (tt *ssls) Delete(id string) error {
+	_, err := tt.client.delete("/SSL/Update", url.Values{"id": {fmt.Sprint(id)}})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//Create create the ssl whith the data in s and return the Ssl created
+func (tt *ssls) Create(s *PartialSsl) (*Ssl, error) {
+	var err error
+	s, err = tt.CreatePartial(s)
+	if err!= nil {
+		return nil, err
+	}
+	return tt.completeSsl(s)
+}
+
+//CreatePartial create the ssl whith the data in s and return the PartialSsl created
+func (tt *ssls) CreatePartial(s *PartialSsl) (*PartialSsl, error) {
+	(*s).ID=0
+	var v url.Values
+	v, _ = query.Values(createSsl(*s))
+	
+	rawResponse, err := tt.client.put("/SSL/Update", v)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating StatusCake Ssl: %s", err.Error())
+	}
+
+	var createResponse sslCreateResponse
+	err = json.NewDecoder(rawResponse.Body).Decode(&createResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if !createResponse.Success {
+		return nil, fmt.Errorf("%s", createResponse.Message.(string))
+	}
+	*s = PartialSsl(createResponse.Input)
+	(*s).ID = int(createResponse.Message.(float64))
+	
+	return s,nil
+}
+

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -99,7 +99,7 @@ type Test struct {
 	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
-	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes" querystringoptions:"omitempty"`
 
 	// Set to 1 to enable the Cookie Jar. Required for some redirects.
 	UseJar int `json:"UseJar" querystring:"UseJar"`

--- a/vendor/github.com/google/go-querystring/LICENSE
+++ b/vendor/github.com/google/go-querystring/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Google. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/go-querystring/query/encode.go
+++ b/vendor/github.com/google/go-querystring/query/encode.go
@@ -1,0 +1,320 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string. Including
+// the "semicolon" option will encode the value as a semicolon-delimited string.
+// Including the "brackets" option signals that the multiple URL values should
+// have "[]" appended to the value name. "numbered" will append a number to
+// the end of each incidence of the value name, example:
+// name0=value0&name1=value1, etc.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// Nested structs are encoded including parent fields in value names for
+// scoping. e.g:
+//
+// 	"user[name]=acme&user[addr][postcode]=1234&user[addr][city]=SFO"
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	values := make(url.Values)
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return values, nil
+		}
+		val = val.Elem()
+	}
+
+	if v == nil {
+		return values, nil
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			if !reflect.Indirect(sv).IsValid() {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			} else if opts.Contains("semicolon") {
+				del = ';'
+			} else if opts.Contains("brackets") {
+				name = name + "[]"
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					k := name
+					if opts.Contains("numbered") {
+						k = fmt.Sprintf("%s%d", name, i)
+					}
+					values.Add(k, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
+		}
+
+		if sv.Kind() == reflect.Struct {
+			reflectValue(values, sv, name)
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/compute/metadata
-# github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb
+# github.com/DreamItGetIT/statuscake v0.0.0-20190726070003-fcee7d205925
 github.com/DreamItGetIT/statuscake
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
@@ -73,6 +73,8 @@ github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
+# github.com/google/go-querystring v1.0.0
+github.com/google/go-querystring/query
 # github.com/googleapis/gax-go/v2 v2.0.3
 github.com/googleapis/gax-go/v2
 # github.com/hashicorp/errwrap v1.0.0


### PR DESCRIPTION
I fixed a bug in the Statuscake client (DreamItGetIT/statuscake/#45) where when `status_codes` was not set the default values that StatusCake applies were not used and you ended up with blank status codes in your test which is not very useful.

This pull request only updates the version of the client and makes no change to the provider itself.

This fixes #43 And also resolved the same issue #40 was trying to resolve.