### PR TITLE
deprecate contact_id from provider example

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -34,6 +34,6 @@ resource "statuscake_test" "google" {
   website_url  = "www.google.com"
   test_type    = "HTTP"
   check_rate   = 300
-  contact_id   = 12345
+  contact_group = ["12345"]
 }
 ```


### PR DESCRIPTION
contact_id is deprecated in favour of contact_group.
Resource documentation was updated, but not the provider page.