### PR TITLE
Upgraded StatusCake client to expose PostBody on provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-statuscake
 
 require (
-	github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb
+	github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9
 	github.com/hashicorp/terraform v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNfDF5AZvjr+5UyGQvQEBL7pwo+v+wX6q9JI8=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb h1:vJ3lnCyZNmSV/OKyw4d7GuZHFrUaa3FY6/NqtvRE0lw=
-github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb/go.mod h1:OclNh7ZacJo61GDJablmsOZ7l8/AVtzGqP8G7baOdAs=
+github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9 h1:mAqrNxLrhgFL6U+YoDhOa/7jz3xlvtOowsaBMiBUkRU=
+github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9/go.mod h1:OclNh7ZacJo61GDJablmsOZ7l8/AVtzGqP8G7baOdAs=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -213,6 +213,11 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 			},
 
+			"post_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"final_endpoint": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -265,6 +270,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		StatusCodes:    d.Get("status_codes").(string),
 		UseJar:         d.Get("use_jar").(int),
 		PostRaw:        d.Get("post_raw").(string),
+		PostBody:       d.Get("post_body").(string),
 		FinalEndpoint:  d.Get("final_endpoint").(string),
 		EnableSSLAlert: d.Get("enable_ssl_alert").(bool),
 		FollowRedirect: d.Get("follow_redirect").(bool),
@@ -363,6 +369,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status_codes", testResp.StatusCodes)
 	d.Set("use_jar", testResp.UseJar)
 	d.Set("post_raw", testResp.PostRaw)
+	d.Set("post_body", testResp.PostBody)
 	d.Set("final_endpoint", testResp.FinalEndpoint)
 	d.Set("enable_ssl_alert", testResp.EnableSSLAlert)
 	d.Set("follow_redirect", testResp.FollowRedirect)
@@ -463,6 +470,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("post_raw"); ok {
 		test.PostRaw = v.(string)
+	}
+	if v, ok := d.GetOk("post_body"); ok {
+		test.PostBody = v.(string)
 	}
 	if v, ok := d.GetOk("final_endpoint"); ok {
 		test.FinalEndpoint = v.(string)

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -113,6 +113,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuscake_test.google", "status_codes", "string23065"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "use_jar", "1"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "post_raw", "string32096"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "post_body", "string32096"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "final_endpoint", "string10781"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "enable_ssl_alert", "false"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "follow_redirect", "true"),
@@ -212,6 +213,8 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.Itoa(test.UseJar))
 			case "post_raw":
 				err = check(key, value, test.PostRaw)
+			case "post_body":
+				err = check(key, value, test.PostBody)
 			case "final_endpoint":
 				err = check(key, value, test.FinalEndpoint)
 			case "enable_ssl_alert":
@@ -299,6 +302,7 @@ resource "statuscake_test" "google" {
 	status_codes = "string23065"
 	use_jar = 1
 	post_raw = "string32096"
+	post_body = "string32096"
 	final_endpoint = "string10781"
 	enable_ssl_alert = false
 	follow_redirect = true

--- a/vendor/github.com/DreamItGetIT/statuscake/Gopkg.lock
+++ b/vendor/github.com/DreamItGetIT/statuscake/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "UT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -30,7 +38,7 @@
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
   pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
@@ -41,8 +49,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DreamItGetIT/statuscake",
+    "github.com/google/go-querystring/query",
     "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/require",
+    "github.com/stretchr/testify/require"
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -29,41 +29,45 @@ type contactGroupDetailResponse struct {
 }
 
 type detailResponse struct {
-	Method          string                       `json:"Method"`
-	TestID          int                          `json:"TestID"`
-	TestType        string                       `json:"TestType"`
-	Paused          bool                         `json:"Paused"`
-	WebsiteName     string                       `json:"WebsiteName"`
-	URI             string                       `json:"URI"`
-	ContactID       int                          `json:"ContactID"`
-	ContactGroups   []contactGroupDetailResponse `json:"ContactGroups"`
-	Status          string                       `json:"Status"`
-	Uptime          float64                      `json:"Uptime"`
-	CustomHeader    string                       `json:"CustomHeader"`
-	UserAgent       string                       `json:"UserAgent"`
-	CheckRate       int                          `json:"CheckRate"`
-	Timeout         int                          `json:"Timeout"`
-	LogoImage       string                       `json:"LogoImage"`
-	Confirmation    int                          `json:"Confirmation,string"`
-	WebsiteHost     string                       `json:"WebsiteHost"`
-	NodeLocations   []string                     `json:"NodeLocations"`
-	FindString      string                       `json:"FindString"`
-	DoNotFind       bool                         `json:"DoNotFind"`
-	LastTested      string                       `json:"LastTested"`
-	NextLocation    string                       `json:"NextLocation"`
-	Port            int                          `json:"Port"`
-	Processing      bool                         `json:"Processing"`
-	ProcessingState string                       `json:"ProcessingState"`
-	ProcessingOn    string                       `json:"ProcessingOn"`
-	DownTimes       int                          `json:"DownTimes,string"`
-	Sensitive       bool                         `json:"Sensitive"`
-	TriggerRate     int                          `json:"TriggerRate,string"`
-	UseJar          int                          `json:"UseJar"`
-	PostRaw         string                       `json:"PostRaw"`
-	FinalEndpoint   string                       `json:"FinalEndpoint"`
-	EnableSSLWarning  bool                       `json:"EnableSSLWarning"`
-	FollowRedirect  bool                         `json:"FollowRedirect"`
-	StatusCodes     []string                     `json:"StatusCodes"`
+	Method           string                       `json:"Method"`
+	TestID           int                          `json:"TestID"`
+	TestType         string                       `json:"TestType"`
+	Paused           bool                         `json:"Paused"`
+	WebsiteName      string                       `json:"WebsiteName"`
+	URI              string                       `json:"URI"`
+	ContactID        int                          `json:"ContactID"`
+	ContactGroups    []contactGroupDetailResponse `json:"ContactGroups"`
+	Status           string                       `json:"Status"`
+	Uptime           float64                      `json:"Uptime"`
+	CustomHeader     string                       `json:"CustomHeader"`
+	UserAgent        string                       `json:"UserAgent"`
+	CheckRate        int                          `json:"CheckRate"`
+	Timeout          int                          `json:"Timeout"`
+	LogoImage        string                       `json:"LogoImage"`
+	Confirmation     int                          `json:"Confirmation,string"`
+	WebsiteHost      string                       `json:"WebsiteHost"`
+	NodeLocations    []string                     `json:"NodeLocations"`
+	FindString       string                       `json:"FindString"`
+	DoNotFind        bool                         `json:"DoNotFind"`
+	LastTested       string                       `json:"LastTested"`
+	NextLocation     string                       `json:"NextLocation"`
+	Port             int                          `json:"Port"`
+	Processing       bool                         `json:"Processing"`
+	ProcessingState  string                       `json:"ProcessingState"`
+	ProcessingOn     string                       `json:"ProcessingOn"`
+	DownTimes        int                          `json:"DownTimes,string"`
+	Sensitive        bool                         `json:"Sensitive"`
+	TriggerRate      int                          `json:"TriggerRate,string"`
+	UseJar           int                          `json:"UseJar"`
+	PostRaw          string                       `json:"PostRaw"`
+	PostBody         string                       `json:"PostBody"`
+	FinalEndpoint    string                       `json:"FinalEndpoint"`
+	EnableSSLWarning bool                         `json:"EnableSSLWarning"`
+	FollowRedirect   bool                         `json:"FollowRedirect"`
+	DNSServer        string                       `json:"DNSServer"`
+	DNSIP            string                       `json:"DNSIP"`
+	StatusCodes      []string                     `json:"StatusCodes"`
+	Tags             []string                     `json:"Tags"`
 }
 
 func (d *detailResponse) test() *Test {
@@ -96,9 +100,13 @@ func (d *detailResponse) test() *Test {
 		TriggerRate:    d.TriggerRate,
 		UseJar:         d.UseJar,
 		PostRaw:        d.PostRaw,
+		PostBody:       d.PostBody,
 		FinalEndpoint:  d.FinalEndpoint,
+		DNSServer:      d.DNSServer,
+		DNSIP:          d.DNSIP,
 		EnableSSLAlert: d.EnableSSLWarning,
 		FollowRedirect: d.FollowRedirect,
 		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
+		TestTags:       d.Tags,
 	}
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -99,13 +99,16 @@ type Test struct {
 	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
-	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes" querystringoptions:"omitempty"`
 
 	// Set to 1 to enable the Cookie Jar. Required for some redirects.
 	UseJar int `json:"UseJar" querystring:"UseJar"`
 
 	// Raw POST data seperated by an ampersand
 	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
+
+	// POST Body data, json
+	PostBody string `json:"PostBody" querystring:"PostBody"`
 
 	// Use to specify the expected Final URL in the testing process
 	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
@@ -115,6 +118,12 @@ type Test struct {
 
 	// Use to specify whether redirects should be followed
 	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
+
+	// DNS Tests only. Hostname or IP of DNS server to use.
+	DNSServer string `json:"DNSServer" querystring:"DNSServer"`
+
+	// DNS Tests only. IP to compare against WebsiteURL value.
+	DNSIP string `json:"DNSIP" querystring:"DNSIP"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -149,8 +158,8 @@ func (t *Test) Validate() error {
 		e["Virus"] = "must be 0 or 1"
 	}
 
-	if t.TestType != "HTTP" && t.TestType != "TCP" && t.TestType != "PING" {
-		e["TestType"] = "must be HTTP, TCP, or PING"
+	if t.TestType != "HTTP" && t.TestType != "TCP" && t.TestType != "PING" && t.TestType != "DNS" {
+		e["TestType"] = "must be HTTP, TCP, DNS or PING"
 	}
 
 	if t.RealBrowser < 0 || t.RealBrowser > 1 {
@@ -162,11 +171,27 @@ func (t *Test) Validate() error {
 	}
 
 	if t.PostRaw != "" && t.TestType != "HTTP" {
-		e["PostRaw"] = "must be HTTP to submit a POST request"
+		e["PostRaw"] = "must be HTTP to submit a POST request with PostRaw"
+	}
+
+	if t.PostBody != "" && t.TestType != "HTTP" {
+		e["PostBody"] = "must be HTTP to submit a POST request with PostBody"
 	}
 
 	if t.FinalEndpoint != "" && t.TestType != "HTTP" {
 		e["FinalEndpoint"] = "must be a Valid URL"
+	}
+
+	if t.TestType == "DNS" && t.DNSIP == "" {
+		e["DNSIP"] = "is required"
+	}
+
+	if t.DNSServer != "" && t.TestType != "DNS" {
+		e["DNSServer"] = "must be only used for DNS type tests"
+	}
+
+	if t.DNSIP != "" && t.TestType != "DNS" {
+		e["DNSIP"] = "must be only used for DNS type tests"
 	}
 
 	if t.CustomHeader != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/compute/metadata
-# github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb
+# github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9
 github.com/DreamItGetIT/statuscake
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
@@ -73,6 +73,8 @@ github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
+# github.com/google/go-querystring v1.0.0
+github.com/google/go-querystring/query
 # github.com/googleapis/gax-go/v2 v2.0.3
 github.com/googleapis/gax-go/v2
 # github.com/hashicorp/errwrap v1.0.0
@@ -242,21 +244,33 @@ go.opencensus.io/internal/tagencoding
 # golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 golang.org/x/crypto/openpgp
 golang.org/x/crypto/bcrypt
+golang.org/x/crypto/cryptobyte
+golang.org/x/crypto/cryptobyte/asn1
+golang.org/x/crypto/chacha20poly1305
+golang.org/x/crypto/curve25519
+golang.org/x/crypto/hkdf
 golang.org/x/crypto/openpgp/armor
 golang.org/x/crypto/openpgp/errors
 golang.org/x/crypto/openpgp/packet
 golang.org/x/crypto/openpgp/s2k
 golang.org/x/crypto/blowfish
+golang.org/x/crypto/internal/chacha20
+golang.org/x/crypto/internal/subtle
+golang.org/x/crypto/poly1305
 golang.org/x/crypto/cast5
 golang.org/x/crypto/openpgp/elgamal
 # golang.org/x/net v0.0.0-20190502183928-7f726cade0ab
 golang.org/x/net/context
 golang.org/x/net/trace
-golang.org/x/net/internal/timeseries
-golang.org/x/net/http2
+golang.org/x/net/http/httpguts
+golang.org/x/net/http/httpproxy
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
-golang.org/x/net/http/httpguts
+golang.org/x/net/dns/dnsmessage
+golang.org/x/net/lif
+golang.org/x/net/route
+golang.org/x/net/internal/timeseries
+golang.org/x/net/http2
 golang.org/x/net/context/ctxhttp
 # golang.org/x/oauth2 v0.0.0-20190220154721-9b3c75971fc9
 golang.org/x/oauth2
@@ -266,6 +280,7 @@ golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82
 golang.org/x/sys/unix
+golang.org/x/sys/cpu
 # golang.org/x/text v0.3.2
 golang.org/x/text/unicode/norm
 golang.org/x/text/transform

--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `status_codes` - (Optional) Comma Separated List of StatusCodes to Trigger Error on. Defaults are "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599".
 * `use_jar` - (Optional) Set to true to enable the Cookie Jar. Required for some redirects. Default is false.
 * `post_raw` - (Optional) Use to populate the RAW POST data field on the test.
+* `post_body` - (Optional) Use to populate the POST Body (formdata) field on the test.
 * `final_endpoint` - (Optional) Use to specify the expected Final URL in the testing process.
 * `enable_ssl_alert` - (Optional) HTTP Tests only. If enabled, tests will send warnings if the SSL certificate is about to expire. Paid users only. Default is false
 * `follow_redirect` - (Optional) Use to specify whether redirects should be followed, set to true to enable. Default is false.


### PR DESCRIPTION
[StatusCake API](https://www.statuscake.com/api/Tests/Get%20All%20Tests.md) has 2 kinds of POST data in the HTTP tests:

- `PostRaw`: This is sent as is to the test url and usually used for sending json content. Support for this feature already exists in the provider.
- `PostBody`: This is sent as formdata to the test url. Users need to specify it in JSON where each key becomes a form attribute. This PR introduces support for this attribute.

**Why add this feature?**
Enabling the consumer of this provider to use an existing feature on StatusCake HTTP API.

Support for the PostBody attribute was added in the statuscake client in this PR: https://github.com/DreamItGetIT/statuscake/pull/53 