### PR TITLE
Include release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+#
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
+# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# secret. If you would rather own your own GPG handling, please fork this action
+# or use an alternative one for key handling.
+#
+# You will need to pass the `--batch` flag to `gpg` in your signing step
+# in `goreleaser` to indicate this is being used in a non-interactive mode.
+#
+name: release
+on:
+  push:
+    tags:
+    - "v*"
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.14
+    - id: import_gp
+      # TODO: move this to HashiCorp namespace or find alternative that is just simple gpg commands
+      # see https://github.com/hashicorp/terraform-provider-scaffolding/issues/22
+      uses: paultyng/ghaction-import-gpg@v2.1.0
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.PASSPHRASE }}
+    - uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,54 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+before:
+  hooks:
+  - go mod tidy
+builds:
+- env:
+  # goreleaser does not work with CGO, it could also complicate
+  # usage by users in CI/CD systems like Terraform Cloud where
+  # they are unable to install libraries.
+  - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+  - -trimpath
+  ldflags:
+  - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+  - freebsd
+  - windows
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  - '386'
+  - arm
+  - arm64
+  ignore:
+  - goos: darwin
+    goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+- artifacts: checksum
+  args:
+  # If you are using this in a GitHub action or some other automated pipeline,
+  # you need to pass the batch flag to indicate its not interactive.
+  - "--batch"
+  - "--local-user"
+  - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+  - "--output"
+  - "${signature}"
+  - "--detach-sign"
+  - "${artifact}"
+release:
+  # If you want to manually examine the release before its live, uncomment this
+  # line:
+  # draft: true
+changelog:
+  skip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
 script:
 - make test
 - make vet
-- make website-test
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,6 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -50,12 +49,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-website-test:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
-
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
-
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website


### PR DESCRIPTION
This provider is published to the Terraform registry using a GitHub
action workflow the invokes the `gorelease` toolchain. `gorelease` will
build, sign and release a build artefact to GitHub. This artefact is
used to publish the provider to the Terraform registry.

Instructions followed from https://www.terraform.io/docs/registry/providers/publishing.html