### PR TITLE
Allow the uptime check address field to be more permissive

### DIFF
--- a/docs/resources/uptime_check.md
+++ b/docs/resources/uptime_check.md
@@ -104,7 +104,7 @@ output "example_com_uptime_check_id" {
 
 Required:
 
-- **address** (String) URL or IP address of the server under test
+- **address** (String) URL, FQDN, or IP address of the server under test
 
 Optional:
 
@@ -120,11 +120,15 @@ Required:
 
 Optional:
 
-- **dns_server** (String) Hostname or IP address of the nameserver to query
+- **dns_server** (String) FQDN or IP address of the nameserver to query
 
 
 <a id="nestedblock--http_check"></a>
 ### Nested Schema for `http_check`
+
+Required:
+
+- **status_codes** (Set of String) List of status codes that trigger an alert
 
 Optional:
 
@@ -137,8 +141,7 @@ Optional:
 - **request_method** (String) Type of HTTP check. Either HTTP, or HEAD
 - **request_payload** (Map of String) Payload submitted with the request. Setting this updates the check to use the HTTP POST verb. Only one of `request_payload` or `request_payload_raw` may be specified
 - **request_payload_raw** (String) Raw payload submitted with the request. Setting this updates the check to use the HTTP POST verb. Only one of `request_payload` or `request_payload_raw` may be specified
-- **status_codes** (Set of String) List of status codes that trigger an alert
-- **timeout** (Number) Time to wait to receive the first byte
+- **timeout** (Number) The number of seconds to wait to receive the first byte
 - **user_agent** (String) Custom user agent string set when testing
 - **validate_ssl** (Boolean) Whether to send an alert if the SSL certificate is soon to expire
 

--- a/internal/provider/resource_ssl_check.go
+++ b/internal/provider/resource_ssl_check.go
@@ -125,8 +125,8 @@ func resourceStatusCakeSSLCheck() *schema.Resource {
 			"user_agent": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
 				Description:  "Custom user agent string set when testing",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}

--- a/internal/provider/resource_uptime_check.go
+++ b/internal/provider/resource_uptime_check.go
@@ -93,8 +93,8 @@ func resourceStatusCakeUptimeCheck() *schema.Resource {
 						"dns_server": &schema.Schema{
 							Type:         schema.TypeString,
 							Optional:     true,
-							Description:  "Hostname or IP address of the nameserver to query",
-							ValidateFunc: validation.IsIPAddress,
+							Description:  "FQDN or IP address of the nameserver to query",
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 					},
 				},
@@ -216,8 +216,8 @@ func resourceStatusCakeUptimeCheck() *schema.Resource {
 						"user_agent": &schema.Schema{
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
 							Description:  "Custom user agent string set when testing",
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"validate_ssl": &schema.Schema{
 							Type:        schema.TypeBool,
@@ -268,8 +268,8 @@ func resourceStatusCakeUptimeCheck() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
-							Description:  "URL or IP address of the server under test",
-							ValidateFunc: validation.Any(validation.IsURLWithHTTPorHTTPS, validation.IsIPAddress),
+							Description:  "URL, FQDN, or IP address of the server under test",
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"host": &schema.Schema{
 							Type:         schema.TypeString,


### PR DESCRIPTION
At present the uptime check address field will only accept values that
begin with an HTTP scheme or are valid IP addresses. This prevents
certain values from being used that would make more sense for particular
test types - for example ICMP, and TCP.

This commit removes the validation from the address field entirely as
otherwise the variation of values would make the field too difficult to
validate.