### PR TITLE
Fix SSL check `on_broken` flag

### DIFF
--- a/internal/provider/resource_ssl_check.go
+++ b/internal/provider/resource_ssl_check.go
@@ -356,7 +356,7 @@ func expandSSLCheckAlertConfig(v interface{}, d *schema.ResourceData) (interface
 	broken, err := expandSSLCheckOnBroken(original["on_broken"], d)
 	if err != nil {
 		return nil, err
-	} else if d.HasChange("alert_config.0.broken") {
+	} else if d.HasChange("alert_config.0.on_broken") {
 		transformed["alert_broken"] = broken
 	}
 


### PR DESCRIPTION
This prevents an error being thrown when the `on_broken` flag is changed.