### PR TITLE
Bump statuscake-go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/StatusCakeDev/terraform-provider-statuscake
 go 1.17
 
 require (
-	github.com/StatusCakeDev/statuscake-go v1.0.0-beta.3
+	github.com/StatusCakeDev/statuscake-go v1.0.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/StatusCakeDev/statuscake-go v1.0.0-beta.3 h1:6yNlBzJOOMphxGDkNJ+1eh3DHMEzqR6yNnY6GSr7yHQ=
-github.com/StatusCakeDev/statuscake-go v1.0.0-beta.3/go.mod h1:Cfu47C+WZqA+iQ6Hg1SGJqNrV9LRcJ0RmoZkSvFPncY=
+github.com/StatusCakeDev/statuscake-go v1.0.0 h1:Fx6R3z3auRNUu75yduV+SLv+Eg5YvVVcOEmIp6V/lCo=
+github.com/StatusCakeDev/statuscake-go v1.0.0/go.mod h1:Cfu47C+WZqA+iQ6Hg1SGJqNrV9LRcJ0RmoZkSvFPncY=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
This commit updates the statuscake-go dependency to use the latest
stable version.