### PR TITLE
Improve error messages returned from the provider

### DIFF
--- a/internal/provider/data_source_monitoring_locations.go
+++ b/internal/provider/data_source_monitoring_locations.go
@@ -2,15 +2,13 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
-	statuscake "github.com/StatusCakeDev/statuscake-go"
 )
 
 type monitoringLocationsFunc func(context.Context, *statuscake.Client, string) (statuscake.MonitoringLocations, error)
@@ -82,11 +80,11 @@ func dataSourceStatusCakeUptimeLocationsRead(fn monitoringLocationsFunc) schema.
 
 		res, err := fn(ctx, client, d.Get("region_code").(string))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to list monitoring locations: %w", err))
+			return diag.Errorf("failed to list monitoring locations: %s", err)
 		}
 
 		if err := d.Set("locations", flattenMonitoringLocations(res.Data, d)); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting monitoring locations: %w", err))
+			return diag.Errorf("error setting monitoring locations: %s", err)
 		}
 
 		d.SetId(strconv.FormatInt(time.Now().Unix(), 10))

--- a/internal/provider/diag/helpers.go
+++ b/internal/provider/diag/helpers.go
@@ -1,0 +1,48 @@
+package diag
+
+import (
+	"strings"
+
+	"github.com/StatusCakeDev/statuscake-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// FromErr will convert an error into a Diagnostics. Each Diagnostic entry will
+// have the summary line prefixed with a contextual message.
+func FromErr(message string, err error) diag.Diagnostics {
+	if err == nil {
+		return nil
+	}
+	return diagnostics(message, err)
+}
+
+func diagnostics(message string, err error) diag.Diagnostics {
+	errs := statuscake.Errors(err)
+	if len(errs) == 0 {
+		return fromErr(message, err)
+	}
+	return violations(message, err, errs)
+}
+
+func fromErr(message string, err error) diag.Diagnostics {
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  message + ": " + err.Error(),
+		},
+	}
+}
+
+func violations(message string, err error, errs map[string][]string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for field, violations := range errs {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  message + ": " + err.Error() + ": " + field + " contains violations",
+
+			// TODO: Use AttributePath to indicate validation errors.
+			Detail: strings.Join(violations, "; "),
+		})
+	}
+	return diags
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"regexp"
 	"runtime"
@@ -14,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	statuscake "github.com/StatusCakeDev/statuscake-go"
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/StatusCakeDev/statuscake-go/backoff"
 	"github.com/StatusCakeDev/statuscake-go/credentials"
 	"github.com/StatusCakeDev/statuscake-go/throttle"
@@ -86,7 +85,7 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	apiToken, ok := d.GetOk("api_token")
 	if !ok {
-		return nil, diag.FromErr(errors.New("credentials are not set correctly"))
+		return nil, diag.Errorf("credentials are not set correctly")
 	}
 
 	bearer := credentials.NewBearerWithStaticToken(apiToken.(string))

--- a/internal/provider/resource_contact_group.go
+++ b/internal/provider/resource_contact_group.go
@@ -6,11 +6,12 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	statuscake "github.com/StatusCakeDev/statuscake-go"
+	intdiag "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/diag"
 	intvalidation "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/validation"
 )
 
@@ -114,7 +115,7 @@ func resourceStatusCakeContactGroupCreate(ctx context.Context, d *schema.Resourc
 
 	res, err := client.CreateContactGroupWithData(ctx, body).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create contact group: %w", err))
+		return intdiag.FromErr("failed to create contact group", err)
 	}
 
 	d.SetId(res.Data.NewID)
@@ -133,27 +134,27 @@ func resourceStatusCakeContactGroupRead(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get contact group with ID: %w", err))
+		return diag.Errorf("failed to get contact group with ID: %s", err)
 	}
 
 	if err := d.Set("email_addresses", flattenContactGroupEmailAddresses(res.Data.EmailAddresses, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read email addresses: %+v", err))
+		return diag.Errorf("failed to read email addresses: %s", err)
 	}
 
 	if err := d.Set("integrations", flattenContactGroupIntegrations(res.Data.Integrations, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read integrations: %+v", err))
+		return diag.Errorf("failed to read integrations: %s", err)
 	}
 
 	if err := d.Set("mobile_numbers", flattenContactGroupMobileNumbers(res.Data.MobileNumbers, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read mobile numbers: %+v", err))
+		return diag.Errorf("failed to read mobile numbers: %s", err)
 	}
 
 	if err := d.Set("name", flattenContactGroupName(res.Data.Name, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read name: %+v", err))
+		return diag.Errorf("failed to read name: %s", err)
 	}
 
 	if err := d.Set("ping_url", flattenContactGroupPingURL(res.Data.PingURL, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to ping url: %+v", err))
+		return diag.Errorf("failed to ping url: %s", err)
 	}
 
 	return nil
@@ -203,7 +204,7 @@ func resourceStatusCakeContactGroupUpdate(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Request body: %+v", body)
 
 	if err := client.UpdateContactGroupWithData(ctx, id, body).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update contact group: %w", err))
+		return intdiag.FromErr(fmt.Sprintf("failed to update contact group with id %s", id), err)
 	}
 
 	return resourceStatusCakeContactGroupRead(ctx, d, meta)
@@ -216,7 +217,7 @@ func resourceStatusCakeContactGroupDelete(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Deleting StatusCake contact group with ID: %s", id)
 
 	if err := client.DeleteContactGroup(ctx, id).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete contact group with id %s: %w", id, err))
+		return intdiag.FromErr(fmt.Sprintf("failed to delete contact group with id %s", id), err)
 	}
 
 	return nil

--- a/internal/provider/resource_maintenance_window.go
+++ b/internal/provider/resource_maintenance_window.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	statuscake "github.com/StatusCakeDev/statuscake-go"
+	intdiag "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/diag"
 	intvalidation "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/validation"
 )
 
@@ -141,7 +142,7 @@ func resourceStatusCakeMaintenanceWindowCreate(ctx context.Context, d *schema.Re
 
 	res, err := client.CreateMaintenanceWindowWithData(ctx, body).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create maintenance window: %w", err))
+		return intdiag.FromErr("failed to create maintenance window", err)
 	}
 
 	d.SetId(res.Data.NewID)
@@ -160,35 +161,35 @@ func resourceStatusCakeMaintenanceWindowRead(ctx context.Context, d *schema.Reso
 		return nil
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get maintenance window test with ID: %w", err))
+		return diag.Errorf("failed to get maintenance window test with ID: %s", err)
 	}
 
 	if err := d.Set("end", flattenMaintenanceWindowEnd(res.Data.End, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read end: %+v", err))
+		return diag.Errorf("failed to read end: %s", err)
 	}
 
 	if err := d.Set("name", flattenMaintenanceWindowName(res.Data.Name, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read name: %+v", err))
+		return diag.Errorf("failed to read name: %s", err)
 	}
 
 	if err := d.Set("repeat_interval", flattenMaintenanceWindowRepeatInterval(res.Data.RepeatInterval, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read repeat interval: %+v", err))
+		return diag.Errorf("failed to read repeat interval: %s", err)
 	}
 
 	if err := d.Set("start", flattenMaintenanceWindowStart(res.Data.Start, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read start: %+v", err))
+		return diag.Errorf("failed to read start: %s", err)
 	}
 
 	if err := d.Set("tags", flattenMaintenanceWindowTags(res.Data.Tags, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read tags: %+v", err))
+		return diag.Errorf("failed to read tags: %s", err)
 	}
 
 	if err := d.Set("tests", flattenMaintenanceWindowTests(res.Data.Tests, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read tests: %+v", err))
+		return diag.Errorf("failed to read tests: %s", err)
 	}
 
 	if err := d.Set("timezone", flattenMaintenanceWindowTimezone(res.Data.Timezone, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read timezone: %+v", err))
+		return diag.Errorf("failed to read timezone: %s", err)
 	}
 
 	return nil
@@ -252,7 +253,7 @@ func resourceStatusCakeMaintenanceWindowUpdate(ctx context.Context, d *schema.Re
 	log.Printf("[DEBUG] Request body: %+v", body)
 
 	if err := client.UpdateMaintenanceWindowWithData(ctx, id, body).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update maintenance window: %w", err))
+		return intdiag.FromErr(fmt.Sprintf("failed to update maintenance window with id %s", id), err)
 	}
 
 	return resourceStatusCakeMaintenanceWindowRead(ctx, d, meta)
@@ -265,7 +266,7 @@ func resourceStatusCakeMaintenanceWindowDelete(ctx context.Context, d *schema.Re
 	log.Printf("[DEBUG] Deleting StatusCake maintenance window with ID: %s", id)
 
 	if err := client.DeleteMaintenanceWindow(ctx, id).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete maintenance window with id %s: %w", id, err))
+		return intdiag.FromErr(fmt.Sprintf("failed to delete maintenance window with id %s", id), err)
 	}
 
 	return nil

--- a/internal/provider/resource_pagespeed_check.go
+++ b/internal/provider/resource_pagespeed_check.go
@@ -6,11 +6,12 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	statuscake "github.com/StatusCakeDev/statuscake-go"
+	intdiag "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/diag"
 	intvalidation "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/validation"
 )
 
@@ -175,7 +176,7 @@ func resourceStatusCakePagespeedCheckCreate(ctx context.Context, d *schema.Resou
 
 	res, err := client.CreatePagespeedTestWithData(ctx, body).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create pagespeed check: %w", err))
+		return intdiag.FromErr("failed to create pagespeed check", err)
 	}
 
 	d.SetId(res.Data.NewID)
@@ -194,35 +195,35 @@ func resourceStatusCakePagespeedCheckRead(ctx context.Context, d *schema.Resourc
 		return nil
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get pagespeed check with ID: %w", err))
+		return diag.Errorf("failed to get pagespeed check with ID: %s", err)
 	}
 
 	if err := d.Set("alert_config", flattenPagespeedCheckAlertConfig(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read alert config: %+v", err))
+		return diag.Errorf("failed to read alert config: %s", err)
 	}
 
 	if err := d.Set("check_interval", flattenPagespeedCheckInterval(res.Data.CheckRate, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read check interval: %+v", err))
+		return diag.Errorf("failed to read check interval: %s", err)
 	}
 
 	if err := d.Set("contact_groups", flattenPagespeedCheckContactGroups(res.Data.ContactGroups, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read contact groups: %+v", err))
+		return diag.Errorf("failed to read contact groups: %s", err)
 	}
 
 	if err := d.Set("location", flattenPagespeedCheckLocation(res.Data.Location, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read location: %+v", err))
+		return diag.Errorf("failed to read location: %s", err)
 	}
 
 	if err := d.Set("monitored_resource", flattenPagespeedCheckMonitoredResource(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read monitored resource: %+v", err))
+		return diag.Errorf("failed to read monitored resource: %s", err)
 	}
 
 	if err := d.Set("name", flattenPagespeedCheckName(res.Data.Name, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read name: %+v", err))
+		return diag.Errorf("failed to read name: %s", err)
 	}
 
 	if err := d.Set("paused", flattenPagespeedCheckPaused(res.Data.Paused, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read paused: %+v", err))
+		return diag.Errorf("failed to read paused: %s", err)
 	}
 
 	return nil
@@ -286,7 +287,7 @@ func resourceStatusCakePagespeedCheckUpdate(ctx context.Context, d *schema.Resou
 	log.Printf("[DEBUG] Request body: %+v", body)
 
 	if err := client.UpdatePagespeedTestWithData(ctx, id, body).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update pagespeed check: %w", err))
+		return intdiag.FromErr(fmt.Sprintf("failed to update pagespeed check with id %s", id), err)
 	}
 
 	return resourceStatusCakePagespeedCheckRead(ctx, d, meta)
@@ -299,7 +300,7 @@ func resourceStatusCakePagespeedCheckDelete(ctx context.Context, d *schema.Resou
 	log.Printf("[DEBUG] Deleting StatusCake pagespeed check with ID: %s", id)
 
 	if err := client.DeletePagespeedTest(ctx, id).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete pagespeed check with id %s: %w", id, err))
+		return intdiag.FromErr(fmt.Sprintf("failed to delete pagespeed check with id %s", id), err)
 	}
 
 	return nil

--- a/internal/provider/resource_ssl_check.go
+++ b/internal/provider/resource_ssl_check.go
@@ -6,11 +6,12 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	statuscake "github.com/StatusCakeDev/statuscake-go"
+	intdiag "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/diag"
 	intvalidation "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/validation"
 )
 
@@ -190,7 +191,7 @@ func resourceStatusCakeSSLCheckCreate(ctx context.Context, d *schema.ResourceDat
 
 	res, err := client.CreateSslTestWithData(ctx, body).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create SSL check: %w", err))
+		return intdiag.FromErr("failed to create SSL check", err)
 	}
 
 	d.SetId(res.Data.NewID)
@@ -209,35 +210,35 @@ func resourceStatusCakeSSLCheckRead(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get SSL check with ID: %w", err))
+		return diag.Errorf("failed to get SSL check with ID: %s", err)
 	}
 
 	if err := d.Set("alert_config", flattenSSLCheckAlertConfig(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read alert config: %+v", err))
+		return diag.Errorf("failed to read alert config: %s", err)
 	}
 
 	if err := d.Set("check_interval", flattenSSLCheckInterval(res.Data.CheckRate, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read check interval: %+v", err))
+		return diag.Errorf("failed to read check interval: %s", err)
 	}
 
 	if err := d.Set("contact_groups", flattenSSLCheckContactGroups(res.Data.ContactGroups, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read contact groups: %+v", err))
+		return diag.Errorf("failed to read contact groups: %s", err)
 	}
 
 	if err := d.Set("follow_redirects", flattenSSLCheckFollowRedirects(res.Data.FollowRedirects, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read follow redirects: %+v", err))
+		return diag.Errorf("failed to read follow redirects: %s", err)
 	}
 
 	if err := d.Set("monitored_resource", flattenSSLCheckMonitoredResource(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read monitored resource: %+v", err))
+		return diag.Errorf("failed to read monitored resource: %s", err)
 	}
 
 	if err := d.Set("paused", flattenSSLCheckPaused(res.Data.Paused, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read paused: %+v", err))
+		return diag.Errorf("failed to read paused: %s", err)
 	}
 
 	if err := d.Set("user_agent", flattenSSLCheckUserAgent(res.Data.UserAgent, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read user agent: %+v", err))
+		return diag.Errorf("failed to read user agent: %s", err)
 	}
 
 	return nil
@@ -301,7 +302,7 @@ func resourceStatusCakeSSLCheckUpdate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Request body: %+v", body)
 
 	if err := client.UpdateSslTestWithData(ctx, id, body).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update SSL check: %w", err))
+		return intdiag.FromErr(fmt.Sprintf("failed to update SSL check with id %s", id), err)
 	}
 
 	return resourceStatusCakeSSLCheckRead(ctx, d, meta)
@@ -314,7 +315,7 @@ func resourceStatusCakeSSLCheckDelete(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Deleting StatusCake SSL check with ID: %s", id)
 
 	if err := client.DeleteSslTest(ctx, id).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete SSL check with id %s: %w", id, err))
+		return intdiag.FromErr(fmt.Sprintf("failed to delete SSL check with id %s", id), err)
 	}
 
 	return nil

--- a/internal/provider/resource_uptime_check.go
+++ b/internal/provider/resource_uptime_check.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/StatusCakeDev/statuscake-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	statuscake "github.com/StatusCakeDev/statuscake-go"
+	intdiag "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/diag"
 	intvalidation "github.com/StatusCakeDev/terraform-provider-statuscake/internal/provider/validation"
 )
 
@@ -479,7 +480,7 @@ func resourceStatusCakeUptimeCheckCreate(ctx context.Context, d *schema.Resource
 
 	res, err := client.CreateUptimeTestWithData(ctx, body).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create uptime test: %w", err))
+		return intdiag.FromErr("failed to create uptime test", err)
 	}
 
 	d.SetId(res.Data.NewID)
@@ -498,55 +499,55 @@ func resourceStatusCakeUptimeCheckRead(ctx context.Context, d *schema.ResourceDa
 		return nil
 	}
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get uptime test with ID: %w", err))
+		return diag.Errorf("failed to get uptime test with ID: %s", err)
 	}
 
 	if err := d.Set("check_interval", flattenUptimeCheckInterval(res.Data.CheckRate, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read check interval: %+v", err))
+		return diag.Errorf("failed to read check interval: %s", err)
 	}
 
 	if err := d.Set("confirmation", flattenUptimeCheckConfirmation(res.Data.Confirmation, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read confirmation: %+v", err))
+		return diag.Errorf("failed to read confirmation: %s", err)
 	}
 
 	if err := d.Set("contact_groups", flattenUptimeCheckContactGroups(res.Data.ContactGroups, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read contact groups: %+v", err))
+		return diag.Errorf("failed to read contact groups: %s", err)
 	}
 
 	if err := d.Set("dns_check", flattenUptimeCheckDNSCheck(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read DNS check: %+v", err))
+		return diag.Errorf("failed to read DNS check: %s", err)
 	}
 
 	if err := d.Set("http_check", flattenUptimeCheckHTTPCheck(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read HTTP check: %+v", err))
+		return diag.Errorf("failed to read HTTP check: %s", err)
 	}
 
 	if err := d.Set("monitored_resource", flattenUptimeCheckMonitoredResource(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read monitored resource: %+v", err))
+		return diag.Errorf("failed to read monitored resource: %s", err)
 	}
 
 	if err := d.Set("name", flattenUptimeCheckName(res.Data.Name, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read name: %+v", err))
+		return diag.Errorf("failed to read name: %s", err)
 	}
 
 	if err := d.Set("paused", flattenUptimeCheckPaused(res.Data.Paused, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read paused: %+v", err))
+		return diag.Errorf("failed to read paused: %s", err)
 	}
 
 	if err := d.Set("locations", flattenMonitoringLocations(res.Data.Servers, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read locations: %+v", err))
+		return diag.Errorf("failed to read locations: %s", err)
 	}
 
 	if err := d.Set("tags", flattenUptimeCheckTags(res.Data.Tags, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read tags: %+v", err))
+		return diag.Errorf("failed to read tags: %s", err)
 	}
 
 	if err := d.Set("tcp_check", flattenUptimeCheckTCPCheck(res.Data, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read TCP check: %+v", err))
+		return diag.Errorf("failed to read TCP check: %s", err)
 	}
 
 	if err := d.Set("trigger_rate", flattenUptimeCheckTriggerRate(res.Data.TriggerRate, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to read trigger rate: %+v", err))
+		return diag.Errorf("failed to read trigger rate: %s", err)
 	}
 
 	return nil
@@ -652,7 +653,7 @@ func resourceStatusCakeUptimeCheckUpdate(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Request body: %+v", body)
 
 	if err := client.UpdateUptimeTestWithData(ctx, id, body).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update uptime test: %w", err))
+		return intdiag.FromErr(fmt.Sprintf("failed to update uptime test with id %s", id), err)
 	}
 
 	return resourceStatusCakeUptimeCheckRead(ctx, d, meta)
@@ -665,7 +666,7 @@ func resourceStatusCakeUptimeCheckDelete(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Deleting StatusCake uptime test with ID: %s", id)
 
 	if err := client.DeleteUptimeTest(ctx, id).Execute(); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete uptime test with id %s: %w", id, err))
+		return intdiag.FromErr(fmt.Sprintf("failed to delete uptime test with id %s", id), err)
 	}
 
 	return nil


### PR DESCRIPTION
For operations that may result in validation errors the API returns an object in the response. The Terraform provider was ignoring these validation errors and not indicating to the user what had gone wrong.

This commit improves the error messages returned by the Terraform provider by creating separate diagnostic values for each violation.