### PR TITLE
feat: allow resource URLs to be updated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/StatusCakeDev/terraform-provider-statuscake/v2
 go 1.19
 
 require (
-	github.com/StatusCakeDev/statuscake-go v1.1.0
+	github.com/StatusCakeDev/statuscake-go v1.2.0
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/StatusCakeDev/statuscake-go v1.1.0 h1:LKetG6j/yiQQTyHbHvu/DGvrJaezLAdRYAOubtRXOn8=
-github.com/StatusCakeDev/statuscake-go v1.1.0/go.mod h1:YefpyhDUs1gLCKXG5F9pPcZAp3rk4JyNkb9dfHbgr1I=
+github.com/StatusCakeDev/statuscake-go v1.2.0 h1:FC1Yu6o2CJHm5hDAcMv1YD+o3neWbhVbYWbkSg3yx9o=
+github.com/StatusCakeDev/statuscake-go v1.2.0/go.mod h1:YefpyhDUs1gLCKXG5F9pPcZAp3rk4JyNkb9dfHbgr1I=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=

--- a/internal/provider/data_source_monitoring_locations.go
+++ b/internal/provider/data_source_monitoring_locations.go
@@ -93,11 +93,11 @@ func dataSourceStatusCakeMonitoringLocationsRead(fn monitoringLocationsFunc) sch
 	}
 }
 
-func listUptimeMonitoringLocations(ctx context.Context, client *statuscake.Client, location string) (statuscake.MonitoringLocations, error) {
+func listUptimeMonitoringLocations(ctx context.Context, client *statuscake.Client, regionCode string) (statuscake.MonitoringLocations, error) {
 	req := client.ListUptimeMonitoringLocations(ctx)
 
-	if len(location) != 0 {
-		req = req.Location(location)
+	if len(regionCode) != 0 {
+		req = req.RegionCode(regionCode)
 	}
 
 	return req.Execute()

--- a/internal/provider/resource_pagespeed_check.go
+++ b/internal/provider/resource_pagespeed_check.go
@@ -89,7 +89,6 @@ func resourceStatusCakePagespeedCheck() *schema.Resource {
 						"address": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							Description:  "URL or IP address of the website under test",
 							ValidateFunc: validation.Any(validation.IsURLWithHTTPorHTTPS, validation.IsIPAddress),
 						},

--- a/internal/provider/resource_ssl_check.go
+++ b/internal/provider/resource_ssl_check.go
@@ -104,7 +104,6 @@ func resourceStatusCakeSSLCheck() *schema.Resource {
 						"address": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							Description:  "URL of the server under test",
 							ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 						},

--- a/internal/provider/resource_uptime_check.go
+++ b/internal/provider/resource_uptime_check.go
@@ -263,7 +263,6 @@ func resourceStatusCakeUptimeCheck() *schema.Resource {
 						"address": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							Description:  "URL, FQDN, or IP address of the server under test",
 							ValidateFunc: validation.StringIsNotEmpty,
 						},


### PR DESCRIPTION
Changing the URL for a StatusCake monitoring resource will no longer force the resource to be recreated.