### PR TITLE
ci: remove explicit cache action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,16 +25,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - run: |
-        go test -v -cover ./...
+    - run: go test -v -cover ./...
       timeout-minutes: 10
       env:
         TF_ACC: "1"


### PR DESCRIPTION
The `setup-go` action caches dependencies by default so there is no need for the separate `actions/cache@v3`.