### PR TITLE
fix(heartbeat): move check URL to top level of resource

### DIFF
--- a/docs/resources/heartbeat_check.md
+++ b/docs/resources/heartbeat_check.md
@@ -17,18 +17,19 @@ description: |-
 
 ### Required
 
-- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. The describes server under test (see [below for nested schema](#nestedblock--monitored_resource))
 - `name` (String) Name of the check
 - `period` (Number) Number of seconds since the last ping before the check is considered down.
 
 ### Optional
 
 - `contact_groups` (Set of String) List of contact group IDs
+- `monitored_resource` (Block List, Max: 1) Monitored resource configuration block. This describes the server under test (see [below for nested schema](#nestedblock--monitored_resource))
 - `paused` (Boolean) Whether the check should be run
 - `tags` (Set of String) List of tags
 
 ### Read-Only
 
+- `check_url` (String) URL of the heartbeat check
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--monitored_resource"></a>
@@ -37,10 +38,6 @@ description: |-
 Optional:
 
 - `host` (String) Name of the hosting provider
-
-Read-Only:
-
-- `address` (String) URL of the heartbeat check
 
 ## Import
 

--- a/docs/resources/pagespeed_check.md
+++ b/docs/resources/pagespeed_check.md
@@ -43,7 +43,7 @@ output "example_com_pagespeed_check_id" {
 
 - `alert_config` (Block List, Min: 1, Max: 1) Alert configuration block. Omitting this block disabled all alerts (see [below for nested schema](#nestedblock--alert_config))
 - `check_interval` (Number) Number of seconds between checks
-- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. The describes server under test (see [below for nested schema](#nestedblock--monitored_resource))
+- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. This describes the server under test (see [below for nested schema](#nestedblock--monitored_resource))
 - `name` (String) Name of the check
 - `region` (String) Region on which to run checks
 

--- a/docs/resources/ssl_check.md
+++ b/docs/resources/ssl_check.md
@@ -47,7 +47,7 @@ output "example_com_ssl_check_id" {
 
 - `alert_config` (Block List, Min: 1, Max: 1) Alert configuration block (see [below for nested schema](#nestedblock--alert_config))
 - `check_interval` (Number) Number of seconds between checks
-- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. The describes server under test (see [below for nested schema](#nestedblock--monitored_resource))
+- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. This describes the server under test (see [below for nested schema](#nestedblock--monitored_resource))
 
 ### Optional
 

--- a/docs/resources/uptime_check.md
+++ b/docs/resources/uptime_check.md
@@ -78,7 +78,7 @@ output "example_com_uptime_check_id" {
 ### Required
 
 - `check_interval` (Number) Number of seconds between checks
-- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. The describes server under test (see [below for nested schema](#nestedblock--monitored_resource))
+- `monitored_resource` (Block List, Min: 1, Max: 1) Monitored resource configuration block. This describes the server under test (see [below for nested schema](#nestedblock--monitored_resource))
 - `name` (String) Name of the check
 
 ### Optional

--- a/internal/provider/resource_heartbeat_check.go
+++ b/internal/provider/resource_heartbeat_check.go
@@ -46,7 +46,7 @@ func resourceStatusCakeHeartbeatCheck() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Monitored resource configuration block. The describes server under test",
+				Description: "Monitored resource configuration block. This describes the server under test",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"host": &schema.Schema{

--- a/internal/provider/resource_pagespeed_check.go
+++ b/internal/provider/resource_pagespeed_check.go
@@ -83,7 +83,7 @@ func resourceStatusCakePagespeedCheck() *schema.Resource {
 				Type:        schema.TypeList,
 				Required:    true,
 				MaxItems:    1,
-				Description: "Monitored resource configuration block. The describes server under test",
+				Description: "Monitored resource configuration block. This describes the server under test",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"address": &schema.Schema{

--- a/internal/provider/resource_ssl_check.go
+++ b/internal/provider/resource_ssl_check.go
@@ -98,7 +98,7 @@ func resourceStatusCakeSSLCheck() *schema.Resource {
 				Type:        schema.TypeList,
 				Required:    true,
 				MaxItems:    1,
-				Description: "Monitored resource configuration block. The describes server under test",
+				Description: "Monitored resource configuration block. This describes the server under test",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"address": &schema.Schema{

--- a/internal/provider/resource_ssl_check.go
+++ b/internal/provider/resource_ssl_check.go
@@ -178,7 +178,7 @@ func resourceStatusCakeSSLCheckCreate(ctx context.Context, d *schema.ResourceDat
 		body["paused"] = paused
 	}
 
-	userAgent, err := expandSSLCheckHostname(d.Get("user_agent"), d)
+	userAgent, err := expandSSLCheckUserAgent(d.Get("user_agent"), d)
 	if err != nil {
 		return diag.FromErr(err)
 	} else if d.HasChange("user_agent") {
@@ -290,7 +290,7 @@ func resourceStatusCakeSSLCheckUpdate(ctx context.Context, d *schema.ResourceDat
 		body["paused"] = paused
 	}
 
-	userAgent, err := expandSSLCheckHostname(d.Get("user_agent"), d)
+	userAgent, err := expandSSLCheckUserAgent(d.Get("user_agent"), d)
 	if err != nil {
 		return diag.FromErr(err)
 	} else if d.HasChange("user_agent") {

--- a/internal/provider/resource_uptime_check.go
+++ b/internal/provider/resource_uptime_check.go
@@ -257,7 +257,7 @@ func resourceStatusCakeUptimeCheck() *schema.Resource {
 				Type:        schema.TypeList,
 				Required:    true,
 				MaxItems:    1,
-				Description: "Monitored resource configuration block. The describes server under test",
+				Description: "Monitored resource configuration block. This describes the server under test",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"address": &schema.Schema{

--- a/internal/provider/resource_uptime_check.go
+++ b/internal/provider/resource_uptime_check.go
@@ -232,7 +232,7 @@ func resourceStatusCakeUptimeCheck() *schema.Resource {
 				MaxItems:    1,
 				Description: "ICMP check configuration block. Only one of `dns_check`, `http_check`, `icmp_check`, and `tcp_check` may be specified",
 				// There are no special fields for an ICMP check. All that is required
-				// is the address which is supplied in the `monitoried_resource` block.
+				// is the address which is supplied in the `monitored_resource` block.
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": &schema.Schema{


### PR DESCRIPTION
Unlike other resource the Heartbeat resource does not accept a URL or hostname as an input parameter. This meant that having it inside of `monitored_resource` made little sense and was causing issues due to the check URL being computed.