### PR TITLE
ci: update signing key

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,8 +18,8 @@ jobs:
     - id: import_gpg
       uses: crazy-max/ghaction-import-gpg@v5
       with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        gpg_private_key: ${{ secrets.ARTEFACT_SIGNING_KEY }}
+        passphrase: ${{ secrets.ARTEFACT_SIGNING_KEY_PASSPHRASE }}
     - uses: goreleaser/goreleaser-action@v4
       with:
         version: latest


### PR DESCRIPTION
When Terraform 1.6 was released the signing key used to verify the release stopped working, but only for this release. Older releases continue to install and verify correctly.

In an attempt to resolve the matter we have created a new signing key and will use this to publish another version of the provider before escalating the matter to HashiCorp.