### PR TITLE
ci(publish): clean dist directory

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: goreleaser/goreleaser-action@v4
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`rm-dist` has been deprecated in favour of `clean`.